### PR TITLE
Add Docker Hub auth token to Pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -23,12 +23,14 @@ resources:
     source:
       repository: "((readonly_private_ecr_repo_url))"
       tag: concourse-builder-latest
-  
+
   - name: upstream
     type: registry-image
     check_every: '6h'
     source:
       repository: jess/img
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
 jobs:
   - name: self-update


### PR DESCRIPTION
Add Docker Hub auth token to allow Concourse pipeline task to pull images from Docker Hub.

We need to do this because Docker Hub will introduce rate limiting on 1 November.

paired: @camdesgov & @sarahseewhy